### PR TITLE
chore: add issue templates for bug reports, features, and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,218 @@
+name: "🐛 Bug report"
+description: Report something that is broken or crashes
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please give a **minimal** repro when you can.
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: Short one-liner of the problem
+      placeholder: "Crash when calling client.listen().v1().v1WebSocket() from a thread"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened?
+      description: Tell us what you saw and what you expected instead
+      placeholder: |
+        Actual:
+        - …
+
+        Expected:
+        - …
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro_steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps; include inputs that matter (model, options, etc.)
+      placeholder: |
+        1. Add deepgram-java-sdk:0.0.1 to build.gradle
+        2. Run the code below
+        3. Observe error XYZ
+    validations:
+      required: true
+
+  - type: textarea
+    id: code
+    attributes:
+      label: Minimal code sample
+      description: Small, runnable example (trim secrets). Attach a gist/repo if easier.
+      render: java
+      placeholder: |
+        DeepgramClient client = DeepgramClient.builder()
+            .apiKey("your-key")
+            .build();
+        // minimal snippet here
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / stack trace
+      description: Full stack trace or error message
+      render: text
+      placeholder: |
+        Exception in thread "main" ...
+            at ...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Transport
+      options:
+        - HTTP
+        - WebSocket
+        - Both / Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: endpoint
+    attributes:
+      label: API endpoint / path
+      placeholder: "/v1/listen/…  or  /v1/speak/…"
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model(s) used
+      placeholder: "nova-3, aura-2-asteria-en, flux-general-en, etc."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: repro_rate
+    attributes:
+      label: How often?
+      options:
+        - Always
+        - Often
+        - Sometimes
+        - Rarely
+        - Only once
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: regression
+    attributes:
+      label: Is this a regression?
+      options:
+        - label: "Yes, it worked in an earlier version"
+          required: false
+
+  - type: input
+    id: worked_version
+    attributes:
+      label: Last working SDK version (if known)
+      placeholder: "0.0.1"
+    validations:
+      required: false
+
+  - type: input
+    id: sdk_version
+    attributes:
+      label: SDK version
+      placeholder: "0.0.1"
+    validations:
+      required: true
+
+  - type: input
+    id: java_version
+    attributes:
+      label: Java version
+      placeholder: "17.0.12"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: Install method
+      options:
+        - Gradle
+        - Maven
+        - From source
+    validations:
+      required: false
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      multiple: true
+      options:
+        - macOS (Intel)
+        - macOS (Apple Silicon)
+        - Linux (x86_64)
+        - Linux (arm64)
+        - Windows
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra_env
+    attributes:
+      label: Environment details
+      description: Anything else? Docker, Spring Boot, Android, corporate network, etc.
+      render: text
+    validations:
+      required: false
+
+  - type: input
+    id: repro_repo
+    attributes:
+      label: Link to minimal repro (optional)
+      placeholder: "https://github.com/yourname/repro"
+    validations:
+      required: false
+
+  - type: input
+    id: session_id
+    attributes:
+      label: Session ID (optional)
+      placeholder: "123e4567-e89b-12d3-a456-426614174000"
+    validations:
+      required: false
+
+  - type: input
+    id: project_id
+    attributes:
+      label: Project ID (optional)
+      placeholder: "proj_abc123"
+    validations:
+      required: false
+
+  - type: input
+    id: request_id
+    attributes:
+      label: Request ID (optional)
+      description: From API error messages or response headers (`dg-request-id`)
+      placeholder: "req_def456"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -1,0 +1,71 @@
+name: "📚 Docs improvement"
+description: Fix or improve documentation, examples, or comments
+title: "[Docs]: "
+labels: ["documentation", "needs-triage"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Affected page or section
+      placeholder: "https://developers.deepgram.com/… or README.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is unclear or wrong?
+      placeholder: "Option X is outdated; code sample fails with 0.0.1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested change
+      render: markdown
+      placeholder: "Replace snippet with… Add note about Java 21…"
+    validations:
+      required: false
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example code (if any)
+      render: java
+      placeholder: "// short snippet"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: parity
+    attributes:
+      label: SDK parity (if relevant)
+      options:
+        - label: This change may need updates in other SDKs
+          required: false
+
+  - type: input
+    id: session_id
+    attributes:
+      label: Session ID (optional)
+      placeholder: "123e4567-e89b-12d3-a456-426614174000"
+    validations:
+      required: false
+
+  - type: input
+    id: project_id
+    attributes:
+      label: Project ID (optional)
+      placeholder: "proj_abc123"
+    validations:
+      required: false
+
+  - type: input
+    id: request_id
+    attributes:
+      label: Request ID (optional)
+      description: From API error messages or response headers (`dg-request-id`)
+      placeholder: "req_def456"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,99 @@
+name: "✨ Feature request"
+description: Suggest a new capability or API
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: "Add async streaming helper for /v1/listen"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What user problem does this address?
+      placeholder: "Today I need to write a lot of boilerplate to stream audio…"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: API shape, flags, defaults. Keep it simple.
+      render: java
+      placeholder: |
+        // Example
+        V1WebSocketClient ws = client.listen().v1().v1WebSocket();
+        ws.connect(V1ConnectOptions.builder().model(ListenV1Model.NOVA3).build());
+        ws.sendMedia(ByteString.of(audioBytes));
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: "Manual OkHttp WebSockets; third-party lib; do nothing"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Java only
+        - All SDKs (parity)
+        - Docs/sample only
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Nice to have
+        - Important
+        - High impact
+        - Blocker
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Extra context / links
+      placeholder: "Related issues, forum threads, benchmarks, etc."
+    validations:
+      required: false
+
+  - type: input
+    id: session_id
+    attributes:
+      label: Session ID (optional)
+      placeholder: "123e4567-e89b-12d3-a456-426614174000"
+    validations:
+      required: false
+
+  - type: input
+    id: project_id
+    attributes:
+      label: Project ID (optional)
+      placeholder: "proj_abc123"
+    validations:
+      required: false
+
+  - type: input
+    id: request_id
+    attributes:
+      label: Request ID (optional)
+      description: From API error messages or response headers (`dg-request-id`)
+      placeholder: "req_def456"
+    validations:
+      required: false


### PR DESCRIPTION
Adds three issue templates matching the Python SDK's templates, adapted for Java:
- Bug report (repro steps, Java version, Maven/Gradle, transport type)
- Feature request (proposed API, scope, priority)
- Docs improvement (affected page, suggested change)