### PR TITLE
fix: switch pom.xml to generic updater for release-please compatibility

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -12,9 +12,8 @@
       "draft": false,
       "extra-files": [
         {
-          "type": "xml",
-          "path": "pom.xml",
-          "xpath": "//project/version"
+          "type": "generic",
+          "path": "pom.xml"
         },
         {
           "type": "generic",


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                             
Switch pom.xml from `xml` xpath updater to `generic` updater in release-please config. The xpath updater doesn't work with `release-type: simple`. The `x-release-please-version` annotation was already added to pom.xml in #21.