### PR TITLE
feat: pluggable transport interface for SageMaker support

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -16,6 +16,9 @@ src/main/java/com/deepgram/AsyncDeepgramClientBuilder.java
 # Fern regen overwrites these with incorrect SDK names and strips the markers.
 src/main/java/com/deepgram/core/ClientOptions.java
 
+# Transport abstraction (pluggable transport for SageMaker, etc.)
+src/main/java/com/deepgram/core/transport/
+
 # Build and project configuration
 build.gradle
 settings.gradle

--- a/README.md
+++ b/README.md
@@ -317,6 +317,69 @@ agentWs.send(audioBytes);
 agentWs.close();
 ```
 
+## Custom Transports
+
+The SDK supports pluggable transports for routing WebSocket connections through alternative infrastructure. Any class implementing `DeepgramTransportFactory` can replace the default OkHttp WebSocket connection.
+
+This is primarily used for **AWS SageMaker** deployments where Deepgram models run on your own SageMaker endpoints.
+
+### SageMaker
+
+Use the separate [`deepgram-sagemaker`](https://github.com/deepgram/deepgram-java-sdk-transport-sagemaker) package to route audio through a SageMaker endpoint:
+
+```groovy
+dependencies {
+    implementation 'com.deepgram:deepgram-java-sdk:0.2.0'
+    implementation 'com.deepgram:deepgram-sagemaker:0.1.0'
+}
+```
+
+```java
+import com.deepgram.sagemaker.SageMakerConfig;
+import com.deepgram.sagemaker.SageMakerTransportFactory;
+
+var factory = new SageMakerTransportFactory(
+    SageMakerConfig.builder()
+        .endpointName("my-deepgram-endpoint")
+        .region("us-west-2")
+        .build()
+);
+
+DeepgramClient client = DeepgramClient.builder()
+    .apiKey("unused")  // SageMaker uses AWS credentials, not Deepgram API keys
+    .transportFactory(factory)
+    .build();
+
+// Use the SDK exactly as normal — the transport is transparent
+var ws = client.listen().v1().websocket();
+ws.onResults(results -> { /* ... */ });
+ws.connect(V1ConnectOptions.builder().model(ListenV1Model.NOVA3).build());
+ws.sendMedia(audioBytes);
+```
+
+See the [SageMaker example](examples/sagemaker/LiveStreamingSageMaker.java) for a complete walkthrough.
+
+### Custom Transport Implementation
+
+To implement your own transport (e.g. for proxies, test doubles, or other infrastructure):
+
+```java
+import com.deepgram.core.transport.DeepgramTransport;
+import com.deepgram.core.transport.DeepgramTransportFactory;
+
+DeepgramTransportFactory myFactory = (url, headers) -> {
+    // Return your DeepgramTransport implementation
+    return new MyCustomTransport(url, headers);
+};
+
+DeepgramClient client = DeepgramClient.builder()
+    .apiKey("your-key")
+    .transportFactory(myFactory)
+    .build();
+```
+
+The `DeepgramTransport` interface provides bidirectional messaging: `sendText()`, `sendBinary()`, and callback registration for incoming messages, errors, and close events.
+
 ## Configuration
 
 ### Custom Timeouts

--- a/examples/sagemaker/LiveStreamingSageMaker.java
+++ b/examples/sagemaker/LiveStreamingSageMaker.java
@@ -1,0 +1,152 @@
+import com.deepgram.DeepgramClient;
+import com.deepgram.resources.listen.v1.types.ListenV1CloseStream;
+import com.deepgram.resources.listen.v1.types.ListenV1CloseStreamType;
+import com.deepgram.resources.listen.v1.types.ListenV1ResultsChannelAlternativesItem;
+import com.deepgram.resources.listen.v1.websocket.V1ConnectOptions;
+import com.deepgram.resources.listen.v1.websocket.V1WebSocketClient;
+import com.deepgram.sagemaker.SageMakerConfig;
+import com.deepgram.sagemaker.SageMakerTransportFactory;
+import com.deepgram.types.ListenV1Model;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import okio.ByteString;
+
+/**
+ * Live transcription via SageMaker endpoint.
+ *
+ * <p>Streams a WAV file through a Deepgram model running on SageMaker using HTTP/2 bidirectional streaming. Audio is
+ * paced to real-time to simulate a live microphone stream.
+ *
+ * <p>Requires the {@code deepgram-sagemaker-java} transport library.
+ *
+ * <p>Usage:
+ *
+ * <pre>
+ *   export SAGEMAKER_ENDPOINT=my-deepgram-endpoint
+ *   export AWS_REGION=us-east-2
+ *   java LiveStreamingSageMaker [path/to/audio.wav]
+ * </pre>
+ *
+ * <p>Environment variables:
+ *
+ * <ul>
+ *   <li>{@code SAGEMAKER_ENDPOINT} — SageMaker endpoint name (default: "deepgram-nova-3")
+ *   <li>{@code AWS_REGION} — AWS region (default: "us-west-2")
+ * </ul>
+ */
+public class LiveStreamingSageMaker {
+
+    public static void main(String[] args) throws Exception {
+        String endpointName = System.getenv().getOrDefault("SAGEMAKER_ENDPOINT", "deepgram-nova-3");
+        String region = System.getenv().getOrDefault("AWS_REGION", "us-west-2");
+
+        // Audio file — from args or default
+        Path audioFile = args.length > 0 ? Path.of(args[0]) : Path.of("spacewalk.wav");
+        if (!Files.exists(audioFile)) {
+            System.err.println("Audio file not found: " + audioFile);
+            System.err.println("Download from: https://dpgr.am/spacewalk.wav");
+            System.exit(1);
+        }
+
+        // Create the SageMaker transport factory
+        SageMakerConfig config = SageMakerConfig.builder()
+                .endpointName(endpointName)
+                .region(region)
+                .build();
+        SageMakerTransportFactory factory = new SageMakerTransportFactory(config);
+
+        // Build the SDK client — apiKey is unused, SageMaker uses AWS credentials
+        DeepgramClient client = DeepgramClient.builder()
+                .apiKey("unused")
+                .transportFactory(factory)
+                .build();
+
+        System.out.println("Live transcription via SageMaker transport");
+        System.out.println("Endpoint: " + endpointName);
+        System.out.println("Region:   " + region);
+        System.out.println();
+
+        // From here, the code is identical to any standard Deepgram SDK usage
+        V1WebSocketClient wsClient = client.listen().v1().v1WebSocket();
+        CountDownLatch done = new CountDownLatch(1);
+
+        wsClient.onResults(result -> {
+            if (result.getChannel() != null
+                    && result.getChannel().getAlternatives() != null
+                    && !result.getChannel().getAlternatives().isEmpty()) {
+                ListenV1ResultsChannelAlternativesItem alt =
+                        result.getChannel().getAlternatives().get(0);
+                String transcript = alt.getTranscript();
+                if (transcript != null && !transcript.isEmpty()) {
+                    boolean isFinal = result.getIsFinal().orElse(false);
+                    System.out.printf("%s %s%n", isFinal ? "[final]  " : "[interim]", transcript);
+                }
+            }
+        });
+
+        wsClient.onMetadata(metadata -> {
+            System.out.println("Metadata: request_id=" + metadata.getRequestId());
+        });
+
+        wsClient.onError(error -> {
+            System.err.println("Error: " + error.getMessage());
+            done.countDown();
+        });
+
+        wsClient.onDisconnected(reason -> {
+            System.out.println("Closed (code: " + reason.getCode() + ")");
+            done.countDown();
+        });
+
+        // Connect
+        CompletableFuture<Void> connectFuture = wsClient.connect(
+                V1ConnectOptions.builder().model(ListenV1Model.NOVA3).build());
+        connectFuture.get(10, TimeUnit.SECONDS);
+        System.out.println("Connected. Streaming audio...\n");
+
+        // Parse WAV header for pacing
+        int sampleRate;
+        int blockAlign;
+        try (RandomAccessFile raf = new RandomAccessFile(audioFile.toFile(), "r")) {
+            raf.skipBytes(24);
+            byte[] srBytes = new byte[4];
+            raf.read(srBytes);
+            sampleRate = ByteBuffer.wrap(srBytes).order(ByteOrder.LITTLE_ENDIAN).getInt();
+
+            raf.skipBytes(4); // skip byte rate
+            byte[] baBytes = new byte[2];
+            raf.read(baBytes);
+            blockAlign = ByteBuffer.wrap(baBytes).order(ByteOrder.LITTLE_ENDIAN).getShort() & 0xFFFF;
+        }
+
+        // Read and send audio paced to real-time (including WAV header)
+        byte[] audio = Files.readAllBytes(audioFile);
+        int chunkSize = 8192;
+        double framesPerChunk = (double) chunkSize / blockAlign;
+        long sleepMicros = (long) (framesPerChunk / sampleRate * 1_000_000);
+
+        for (int i = 0; i < audio.length; i += chunkSize) {
+            int end = Math.min(i + chunkSize, audio.length);
+            byte[] chunk = new byte[end - i];
+            System.arraycopy(audio, i, chunk, 0, chunk.length);
+            wsClient.sendMedia(ByteString.of(chunk));
+            TimeUnit.MICROSECONDS.sleep(sleepMicros);
+        }
+
+        // Signal end of audio
+        wsClient.sendCloseStream(ListenV1CloseStream.builder()
+                .type(ListenV1CloseStreamType.CLOSE_STREAM)
+                .build());
+
+        done.await(60, TimeUnit.SECONDS);
+        wsClient.disconnect();
+        factory.shutdown();
+        System.out.println("Done.");
+    }
+}

--- a/src/main/java/com/deepgram/AsyncDeepgramClientBuilder.java
+++ b/src/main/java/com/deepgram/AsyncDeepgramClientBuilder.java
@@ -16,6 +16,8 @@ package com.deepgram;
 import com.deepgram.core.ClientOptions;
 import com.deepgram.core.Environment;
 import com.deepgram.core.LogConfig;
+import com.deepgram.core.transport.DeepgramTransportFactory;
+import com.deepgram.core.transport.TransportWebSocketFactory;
 import java.util.UUID;
 import okhttp3.OkHttpClient;
 
@@ -25,6 +27,18 @@ public class AsyncDeepgramClientBuilder extends AsyncDeepgramApiClientBuilder {
     private String sessionId;
 
     private String apiKeyValue = System.getenv("DEEPGRAM_API_KEY");
+
+    private DeepgramTransportFactory transportFactory;
+
+    /**
+     * Sets a custom transport factory for all WebSocket connections. When set, WebSocket clients will use this factory
+     * instead of the default OkHttp WebSocket. Use this to route Deepgram API calls through alternative transports such
+     * as SageMaker HTTP/2 streaming.
+     */
+    public AsyncDeepgramClientBuilder transportFactory(DeepgramTransportFactory transportFactory) {
+        this.transportFactory = transportFactory;
+        return this;
+    }
 
     /**
      * Sets an access token (JWT) for Bearer authentication. If provided, this takes precedence over apiKey and sets the
@@ -102,6 +116,9 @@ public class AsyncDeepgramClientBuilder extends AsyncDeepgramApiClientBuilder {
     protected void setAdditional(ClientOptions.Builder builder) {
         String sid = (sessionId != null) ? sessionId : UUID.randomUUID().toString();
         builder.addHeader("x-deepgram-session-id", sid);
+        if (transportFactory != null) {
+            builder.webSocketFactory(new TransportWebSocketFactory(transportFactory));
+        }
     }
 
     @Override

--- a/src/main/java/com/deepgram/DeepgramClientBuilder.java
+++ b/src/main/java/com/deepgram/DeepgramClientBuilder.java
@@ -15,6 +15,8 @@ package com.deepgram;
 import com.deepgram.core.ClientOptions;
 import com.deepgram.core.Environment;
 import com.deepgram.core.LogConfig;
+import com.deepgram.core.transport.DeepgramTransportFactory;
+import com.deepgram.core.transport.TransportWebSocketFactory;
 import java.util.UUID;
 import okhttp3.OkHttpClient;
 
@@ -24,6 +26,18 @@ public class DeepgramClientBuilder extends DeepgramApiClientBuilder {
     private String sessionId;
 
     private String apiKeyValue = System.getenv("DEEPGRAM_API_KEY");
+
+    private DeepgramTransportFactory transportFactory;
+
+    /**
+     * Sets a custom transport factory for all WebSocket connections. When set, WebSocket clients will use this factory
+     * instead of the default OkHttp WebSocket. Use this to route Deepgram API calls through alternative transports such
+     * as SageMaker HTTP/2 streaming.
+     */
+    public DeepgramClientBuilder transportFactory(DeepgramTransportFactory transportFactory) {
+        this.transportFactory = transportFactory;
+        return this;
+    }
 
     /**
      * Sets an access token (JWT) for Bearer authentication. If provided, this takes precedence over apiKey and sets the
@@ -101,6 +115,9 @@ public class DeepgramClientBuilder extends DeepgramApiClientBuilder {
     protected void setAdditional(ClientOptions.Builder builder) {
         String sid = (sessionId != null) ? sessionId : UUID.randomUUID().toString();
         builder.addHeader("x-deepgram-session-id", sid);
+        if (transportFactory != null) {
+            builder.webSocketFactory(new TransportWebSocketFactory(transportFactory));
+        }
     }
 
     @Override

--- a/src/main/java/com/deepgram/core/transport/DeepgramTransport.java
+++ b/src/main/java/com/deepgram/core/transport/DeepgramTransport.java
@@ -1,0 +1,54 @@
+package com.deepgram.core.transport;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/**
+ * Pluggable transport interface for Deepgram WebSocket APIs.
+ *
+ * <p>The default SDK transport uses OkHttp WebSockets. Alternative implementations — such as
+ * SageMaker HTTP/2 streaming — can be injected via {@link DeepgramTransportFactory}.
+ *
+ * <p>This interface models the same bidirectional messaging pattern as a WebSocket: send
+ * text/binary messages, receive text/binary messages via callbacks, and close when done.
+ */
+public interface DeepgramTransport extends AutoCloseable {
+
+    /** Send binary data (audio frames) asynchronously. */
+    CompletableFuture<Void> sendBinary(byte[] data);
+
+    /** Send text data (JSON control messages) asynchronously. */
+    CompletableFuture<Void> sendText(String data);
+
+    /** Register a listener for incoming text messages (JSON responses). */
+    void onTextMessage(Consumer<String> listener);
+
+    /** Register a listener for incoming binary messages (audio data). */
+    void onBinaryMessage(Consumer<byte[]> listener);
+
+    /** Register a listener invoked when the connection is established. */
+    void onOpen(Runnable listener);
+
+    /** Register a listener for transport errors. */
+    void onError(Consumer<Throwable> listener);
+
+    /**
+     * Register a listener for transport close events.
+     *
+     * @param listener receives the close code (e.g. 1000 for normal) and reason
+     */
+    void onClose(CloseListener listener);
+
+    /** Returns true if the transport connection is open. */
+    boolean isOpen();
+
+    /** Close the transport gracefully. */
+    @Override
+    void close();
+
+    /** Listener for close events. */
+    @FunctionalInterface
+    interface CloseListener {
+        void onClose(int code, String reason);
+    }
+}

--- a/src/main/java/com/deepgram/core/transport/DeepgramTransportFactory.java
+++ b/src/main/java/com/deepgram/core/transport/DeepgramTransportFactory.java
@@ -1,0 +1,34 @@
+package com.deepgram.core.transport;
+
+import java.util.Map;
+
+/**
+ * Factory for creating {@link DeepgramTransport} instances. Injected into the Deepgram client
+ * builder to replace the default OkHttp WebSocket transport with alternatives like SageMaker HTTP/2
+ * streaming.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * DeepgramClient client = DeepgramClient.builder()
+ *     .apiKey("unused")  // SageMaker uses AWS credentials
+ *     .transportFactory(mySageMakerFactory)
+ *     .build();
+ * }</pre>
+ *
+ * <p>When a transport factory is set, all WebSocket clients (Listen, Speak, Agent) will use it
+ * instead of the default OkHttp WebSocket connection.
+ */
+@FunctionalInterface
+public interface DeepgramTransportFactory {
+
+    /**
+     * Create a transport connection.
+     *
+     * @param url the full Deepgram endpoint URL including query parameters (e.g.
+     *     wss://api.deepgram.com/v1/listen?model=nova-3)
+     * @param headers authentication and configuration headers
+     * @return a connected or connecting transport instance
+     */
+    DeepgramTransport create(String url, Map<String, String> headers);
+}

--- a/src/main/java/com/deepgram/core/transport/TransportWebSocketAdapter.java
+++ b/src/main/java/com/deepgram/core/transport/TransportWebSocketAdapter.java
@@ -1,0 +1,82 @@
+package com.deepgram.core.transport;
+
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okio.ByteString;
+
+/**
+ * Adapts a {@link DeepgramTransport} to the OkHttp {@link WebSocket} interface.
+ *
+ * <p>This allows custom transports to be used transparently with the generated WebSocket clients
+ * via the existing {@link com.deepgram.core.WebSocketFactory} seam — no modifications to
+ * Fern-generated code required.
+ *
+ * <p>The adapter:
+ * <ul>
+ *   <li>Bridges {@code send(String)} / {@code send(ByteString)} to the transport's async methods
+ *   <li>Routes transport callbacks ({@code onOpen}, {@code onTextMessage}, etc.) back to the
+ *       OkHttp {@link WebSocketListener}
+ *   <li>Bridges {@code close()} to the transport's close method
+ * </ul>
+ */
+class TransportWebSocketAdapter implements WebSocket {
+    private final DeepgramTransport transport;
+    private final Request request;
+
+    TransportWebSocketAdapter(DeepgramTransport transport, Request request, WebSocketListener listener) {
+        this.transport = transport;
+        this.request = request;
+
+        transport.onOpen(() -> listener.onOpen(this, new Response.Builder()
+                .request(request)
+                .protocol(okhttp3.Protocol.HTTP_1_1)
+                .code(101)
+                .message("Switching Protocols")
+                .build()));
+
+        transport.onTextMessage(text -> listener.onMessage(this, text));
+
+        transport.onBinaryMessage(bytes -> listener.onMessage(this, ByteString.of(bytes)));
+
+        transport.onError(error -> listener.onFailure(this, error, null));
+
+        transport.onClose((code, reason) -> listener.onClosed(this, code, reason != null ? reason : ""));
+    }
+
+    @Override
+    public Request request() {
+        return request;
+    }
+
+    @Override
+    public long queueSize() {
+        return 0;
+    }
+
+    @Override
+    public boolean send(String text) {
+        if (!transport.isOpen()) return false;
+        transport.sendText(text);
+        return true;
+    }
+
+    @Override
+    public boolean send(ByteString bytes) {
+        if (!transport.isOpen()) return false;
+        transport.sendBinary(bytes.toByteArray());
+        return true;
+    }
+
+    @Override
+    public boolean close(int code, String reason) {
+        transport.close();
+        return true;
+    }
+
+    @Override
+    public void cancel() {
+        transport.close();
+    }
+}

--- a/src/main/java/com/deepgram/core/transport/TransportWebSocketFactory.java
+++ b/src/main/java/com/deepgram/core/transport/TransportWebSocketFactory.java
@@ -1,0 +1,50 @@
+package com.deepgram.core.transport;
+
+import com.deepgram.core.WebSocketFactory;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import okhttp3.Request;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+
+/**
+ * A {@link WebSocketFactory} that delegates to a {@link DeepgramTransportFactory}.
+ *
+ * <p>This bridges the generated SDK's {@code WebSocketFactory} seam with the pluggable transport
+ * system. When the generated WebSocket clients call {@code webSocketFactory.create(request,
+ * listener)}, this class:
+ *
+ * <ol>
+ *   <li>Extracts the URL and headers from the OkHttp {@link Request}
+ *   <li>Calls the {@link DeepgramTransportFactory} to create a {@link DeepgramTransport}
+ *   <li>Wraps the transport in a {@link TransportWebSocketAdapter} that implements {@link WebSocket}
+ * </ol>
+ *
+ * <p>This means zero changes to any Fern-generated code.
+ */
+public class TransportWebSocketFactory implements WebSocketFactory {
+    private final DeepgramTransportFactory transportFactory;
+
+    public TransportWebSocketFactory(DeepgramTransportFactory transportFactory) {
+        this.transportFactory = transportFactory;
+    }
+
+    @Override
+    public WebSocket create(Request request, WebSocketListener listener) {
+        String url = request.url().toString();
+        // Restore wss:// scheme — OkHttp's HttpUrl normalizes to https://
+        if (url.startsWith("https://")) {
+            url = "wss://" + url.substring("https://".length());
+        } else if (url.startsWith("http://")) {
+            url = "ws://" + url.substring("http://".length());
+        }
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        for (String name : request.headers().names()) {
+            headers.put(name, request.header(name));
+        }
+
+        DeepgramTransport transport = transportFactory.create(url, headers);
+        return new TransportWebSocketAdapter(transport, request, listener);
+    }
+}


### PR DESCRIPTION
## Summary                                 

- Adds `DeepgramTransport` and `DeepgramTransportFactory` interfaces for replacing the default OkHttp WebSocket with custom transports    
- Adds `TransportWebSocketAdapter` that bridges custom transports to the existing OkHttp WebSocket interface — zero changes to Fern-generated code                       
- Adds `.transportFactory()` to both `DeepgramClientBuilder` and `AsyncDeepgramClientBuilder`
- Updates `.fernignore` to protect new files from regeneration
- Adds SageMaker example showing how to wire up a custom transport

## Context                                 

This enables the separate `deepgram-java-sdk-transport-sagemaker` package to route Deepgram API calls through AWS SageMaker endpoints using HTTP/2 bidirectional streaming. The transport abstraction is generic — any custom transport can be plugged in.