### PR TITLE
fix: emit repeated keyterm query params for multi-keyterm streaming

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -32,6 +32,14 @@ src/main/java/com/deepgram/core/ReconnectingWebSocketListener.java
 src/main/java/com/deepgram/resources/speak/v2/websocket/V2WebSocketClient.java
 src/main/java/com/deepgram/resources/listen/v2/websocket/V2WebSocketClient.java
 
+# Multi-keyterm serialization fix: the generated streaming clients stringified a
+# List<String> keyterm into a single query param (keyterm=[a, b]) instead of
+# repeated params (keyterm=a&keyterm=b), which the server treats as one nonsense
+# term and which degrades recognition. Patched to emit one param per term. The v2
+# listen client is already frozen above; freeze the v1 listen client here too so the
+# fix survives regen. Re-apply after regen; unfreeze once fixed in the generator.
+src/main/java/com/deepgram/resources/listen/v1/websocket/V1WebSocketClient.java
+
 # Manual equals/hashCode contract fix: Fern generates equals() (all instances equal) but no
 # hashCode() for fields-less message types, violating the Object contract. We add a consistent
 # hashCode() to each. Unfreeze and drop these patches once the generator emits a matching

--- a/.fernignore
+++ b/.fernignore
@@ -29,6 +29,8 @@ src/main/java/com/deepgram/core/ReconnectingWebSocketListener.java
 # server control frames look fatal to deployed clients. Patched to a no-op (the raw
 # frame is still delivered via onMessage(String)); mirrors the JS/Python SDKs. Re-apply
 # after regen. Unfreeze once the generator stops treating unknown frames as errors.
+# NOTE: the listen v2 client below also carries the multi-keyterm fix documented lower down
+# (keep it frozen until BOTH that fix and this one are upstreamed).
 src/main/java/com/deepgram/resources/speak/v2/websocket/V2WebSocketClient.java
 src/main/java/com/deepgram/resources/listen/v2/websocket/V2WebSocketClient.java
 

--- a/src/main/java/com/deepgram/resources/listen/v1/websocket/V1WebSocketClient.java
+++ b/src/main/java/com/deepgram/resources/listen/v1/websocket/V1WebSocketClient.java
@@ -147,8 +147,17 @@ public class V1WebSocketClient implements AutoCloseable {
                     String.valueOf(options.getInterimResults().get()));
         }
         if (options.getKeyterm() != null && options.getKeyterm().isPresent()) {
-            urlBuilder.addQueryParameter(
-                    "keyterm", String.valueOf(options.getKeyterm().get()));
+            // keyterm is a String | List<String> union. Emit one query param per term
+            // (keyterm=a&keyterm=b) rather than stringifying the whole list into a single
+            // param, which the server would treat as one nonsense term.
+            Object keytermValue = options.getKeyterm().get().get();
+            if (keytermValue instanceof Iterable) {
+                for (Object term : (Iterable<?>) keytermValue) {
+                    urlBuilder.addQueryParameter("keyterm", String.valueOf(term));
+                }
+            } else {
+                urlBuilder.addQueryParameter("keyterm", String.valueOf(keytermValue));
+            }
         }
         if (options.getKeywords() != null && options.getKeywords().isPresent()) {
             urlBuilder.addQueryParameter(

--- a/src/main/java/com/deepgram/resources/listen/v2/websocket/V2WebSocketClient.java
+++ b/src/main/java/com/deepgram/resources/listen/v2/websocket/V2WebSocketClient.java
@@ -125,8 +125,17 @@ public class V2WebSocketClient implements AutoCloseable {
                     "eot_timeout_ms", String.valueOf(options.getEotTimeoutMs().get()));
         }
         if (options.getKeyterm() != null && options.getKeyterm().isPresent()) {
-            urlBuilder.addQueryParameter(
-                    "keyterm", String.valueOf(options.getKeyterm().get()));
+            // keyterm is a String | List<String> union. Emit one query param per term
+            // (keyterm=a&keyterm=b) rather than stringifying the whole list into a single
+            // param, which the server would treat as one nonsense term.
+            Object keytermValue = options.getKeyterm().get().get();
+            if (keytermValue instanceof Iterable) {
+                for (Object term : (Iterable<?>) keytermValue) {
+                    urlBuilder.addQueryParameter("keyterm", String.valueOf(term));
+                }
+            } else {
+                urlBuilder.addQueryParameter("keyterm", String.valueOf(keytermValue));
+            }
         }
         if (options.getLanguageHint() != null && options.getLanguageHint().isPresent()) {
             urlBuilder.addQueryParameter(

--- a/src/test/java/com/deepgram/ListenV1ConnectWireTest.java
+++ b/src/test/java/com/deepgram/ListenV1ConnectWireTest.java
@@ -1,0 +1,79 @@
+package com.deepgram;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.deepgram.core.Environment;
+import com.deepgram.resources.listen.v1.websocket.V1ConnectOptions;
+import com.deepgram.types.ListenV1Keyterm;
+import com.deepgram.types.ListenV1Model;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import okhttp3.HttpUrl;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Hand-written connect-handshake wire coverage for the {@code keyterm} query param on
+ * {@code listen().v1().v1WebSocket().connect(...)} (GET /v1/listen upgrade).
+ *
+ * <p>Guards that a multi-value keyterm serializes as repeated params ({@code keyterm=a&keyterm=b})
+ * rather than a single stringified list ({@code keyterm=[a, b]}), which the server would treat as
+ * one nonsense term. Frozen via {@code src/test/} in .fernignore.
+ */
+class ListenV1ConnectWireTest {
+    private MockWebServer server;
+    private DeepgramClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        String base = server.url("/").toString().replaceAll("/$", "");
+        Environment env = Environment.custom()
+                .base(base)
+                .production(base)
+                .agent(base)
+                .agentRest(base)
+                .build();
+        client = DeepgramClient.builder().apiKey("test").environment(env).build();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    private HttpUrl connectAndCaptureUrl(V1ConnectOptions options) throws Exception {
+        server.enqueue(new MockResponse().withWebSocketUpgrade(new WebSocketListener() {
+            @Override
+            public void onOpen(WebSocket webSocket, okhttp3.Response response) {
+                webSocket.close(1000, null);
+            }
+        }));
+        client.listen().v1().v1WebSocket().connect(options);
+        RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(request).as("handshake request was sent").isNotNull();
+        HttpUrl url = HttpUrl.parse(server.url("/").scheme() + "://" + request.getHeader("Host") + request.getPath());
+        assertThat(url).as("parsed handshake URL").isNotNull();
+        assertThat(url.encodedPath()).isEqualTo("/v1/listen");
+        return url;
+    }
+
+    @Test
+    @DisplayName("multiple keyterms are sent as repeated params, not a stringified list")
+    void keytermListSentAsRepeatedParams() throws Exception {
+        HttpUrl url = connectAndCaptureUrl(V1ConnectOptions.builder()
+                .model(ListenV1Model.NOVA3)
+                .keyterm(ListenV1Keyterm.of(List.of("a", "b")))
+                .build());
+
+        assertThat(url.queryParameterValues("keyterm")).containsExactly("a", "b");
+    }
+}

--- a/src/test/java/com/deepgram/ListenV2ConnectWireTest.java
+++ b/src/test/java/com/deepgram/ListenV2ConnectWireTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.deepgram.core.Environment;
 import com.deepgram.resources.listen.v2.websocket.V2ConnectOptions;
+import com.deepgram.types.ListenV2Keyterm;
 import com.deepgram.types.ListenV2Model;
 import com.deepgram.types.ListenV2Numerals;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
 import okhttp3.WebSocket;
@@ -19,8 +21,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Hand-written connect-handshake wire coverage for the Flux STT {@code numerals} query param on
- * {@code listen().v2().v2WebSocket().connect(...)} (GET /v2/listen upgrade).
+ * Hand-written connect-handshake wire coverage for Flux STT connect query params ({@code numerals}
+ * and {@code keyterm}) on {@code listen().v2().v2WebSocket().connect(...)} (GET /v2/listen upgrade).
  *
  * <p>The Fern generator did not emit a wire test for the /v2/listen handshake, so this fills the
  * gap for the 2026-07-20 regen's new {@code numerals} option: it pins that {@code numerals=true}
@@ -87,5 +89,27 @@ class ListenV2ConnectWireTest {
                 V2ConnectOptions.builder().model(ListenV2Model.FLUX_GENERAL_EN).build());
 
         assertThat(url.queryParameterNames()).doesNotContain("numerals");
+    }
+
+    @Test
+    @DisplayName("multiple keyterms are sent as repeated params, not a stringified list")
+    void keytermListSentAsRepeatedParams() throws Exception {
+        HttpUrl url = connectAndCaptureUrl(V2ConnectOptions.builder()
+                .model(ListenV2Model.FLUX_GENERAL_EN)
+                .keyterm(ListenV2Keyterm.of(List.of("a", "b")))
+                .build());
+
+        assertThat(url.queryParameterValues("keyterm")).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("a single string keyterm is sent as one param")
+    void keytermStringSentAsOneParam() throws Exception {
+        HttpUrl url = connectAndCaptureUrl(V2ConnectOptions.builder()
+                .model(ListenV2Model.FLUX_GENERAL_EN)
+                .keyterm(ListenV2Keyterm.of("a"))
+                .build());
+
+        assertThat(url.queryParameterValues("keyterm")).containsExactly("a");
     }
 }


### PR DESCRIPTION
## Summary

The listen v1 (Nova-3) and v2 (Flux) streaming WebSocket clients mis-serialize a multi-value `keyterm`. When `keyterm` is a `List<String>`, the client stringifies the whole list into a single query param instead of emitting repeated params:

```
❌ keyterm=%5Ba%2C+b%5D        // one param, value "[a, b]"
✅ keyterm=a&keyterm=b          // one param per term (correct)
```

Per the [keyterm docs](https://developers.deepgram.com/docs/keyterm), multiple key terms must be sent as repeated `keyterm=` params. The server treats the stringified list as a single nonsense term, so instead of boosting the intended terms, it degrades recognition of them.

## Root cause

Both streaming clients build the query with:

```java
urlBuilder.addQueryParameter("keyterm", String.valueOf(options.getKeyterm().get()));
```

`String.valueOf(...)` on a `List<String>` yields Java's list `toString()` — `[a, b]` — which okhttp then percent-encodes into one param. The prerecorded/REST path is unaffected (it uses `QueryStringMapper` with `arraysAsRepeats`).

## Fix

Emit one `keyterm` param per term in both streaming clients (`instanceof Iterable` handles the `List` case; scalar string keyterms are unchanged). Also freeze `V1WebSocketClient.java` in `.fernignore` — `V2WebSocketClient.java` was already frozen, so otherwise the v1 fix would be lost on the next Fern regeneration.

## Impact

- Single-string keyterms: unchanged.
- Multi-keyterm streaming: now correct. Before this fix there was no way to send more than one keyterm on a streaming connection — `of(List.of(...))` mangled the value, and even a one-element list produced `[term]`.

## Tests

Added connect-handshake wire coverage (MockWebServer, asserting the captured upgrade URL):

- `ListenV2ConnectWireTest` (Flux): list → repeated params; single string → one param.
- `ListenV1ConnectWireTest` (Nova-3, new): list → repeated params.

Existing `numerals` wire tests still pass. `./gradlew spotlessJavaCheck test` is green.

## Manual verification

Streamed a real audio clip to Flux (`flux-general-en`) with a two-element keyterm list, real-time paced:

| keyterm | before | after |
|---|---|---|
| `List.of("a", "b")` | boosted term consistently mis-transcribed (6/6) | correct (5/5) |
| `"a"` (single) | correct | correct |
| none | correct | correct |
